### PR TITLE
support exec without arguments.

### DIFF
--- a/nw
+++ b/nw
@@ -61,4 +61,8 @@ cli
   .alias('r')
   .action(remove)
 
-cli.parse(process.argv)
+const inst = cli.parse(process.argv)
+
+if(!inst.args.length) {
+  cli.outputHelp()
+}


### PR DESCRIPTION
Hey, this tool is useful, but when i use it at first time by exec ```nw```, i found a problem: there's nothing output.

maybe you should let it support exec without any arguments, just like other cli.

if it doesn't work without correct number of arguments, show people how to use it, not keep silent.

: )